### PR TITLE
Updated YouTube link, added Twitter link

### DIFF
--- a/_data/page_resources.yml
+++ b/_data/page_resources.yml
@@ -12,6 +12,10 @@ categories:
       link: https://www.facebook.com/PalyRobotics
       title: Paly Robotics Facebook
       description: The Paly Robotics Facebook page, which contains updates for the team.
+    -
+      link: https://twitter.com/frc8
+      title: Paly Robotics Twitter
+      description: The Paly Robotics Twitter page, which contains bite-sized updates for the team.
   -
     name: Team Forms
     links:


### PR DESCRIPTION
The YouTube link pointed to our old channel, which no one has the credentials for :( I updated it to point to our new channel. I also added in our Twitter page link, because that's where most of our social media presence is now.
