### PR TITLE
Fix broken link in carousel

### DIFF
--- a/_data/index_carousel.yml
+++ b/_data/index_carousel.yml
@@ -11,7 +11,7 @@
 -
  link: /assets/img/carousel/carousel-img3.jpg
  caption: It's been an exciting year for Team 8. Watch Paly Robotics' 2016 Year in Review video here!
- url: https://www.youtube.com/watch?v=Rdb7xZ_6Eqk&feature=youtu.be
+ url: https://www.youtube.com/watch?v=ueb6V6h4ogc
 -
  link: /assets/img/carousel/carousel-img4.jpg
  caption: Team 8's FIRST Stronghold robot, Tyr.


### PR DESCRIPTION
The link to the old year in review video no longer works, so I have updated it with the new link.
